### PR TITLE
Adds WAI-aria 1.3 FPWD info

### DIFF
--- a/index.md
+++ b/index.md
@@ -106,7 +106,7 @@ Recommendation on 6 June 2023.
 * new attributes: aria-description, aria-braillelabel, aria-brailleroledescription
 * updates to aria-details to allow multiple IDrefs
 
-Additional changes are in the [changelog](https://www.w3.org/TR/wai-aria-1.3/#changelog)
+Additional changes are in the [changelog](https://www.w3.org/TR/wai-aria-1.3/#changelog).
 
 ### WAI-ARIA 1.2 {#wai-aria-1_2}
 

--- a/index.md
+++ b/index.md
@@ -101,7 +101,10 @@ It describes considerations that might not be evident to most authors from the W
 * [WAI-ARIA 1.2](/TR/wai-aria-1.2/) was published as a completed W3C 
 Recommendation on 06 June 2023.
 
-* [WAI-ARIA 1.3](/TR/wai-aria-1.3/) is under development. First Public Working Draft (FPWD) was published 23 January 2024.
+* [WAI-ARIA 1.3](/TR/wai-aria-1.3/) is under development. Proposed changes from ARIA 1.2 include:
+  * new roles: suggestion, comment, mark
+  * new attributes: aria-description, aria-braillelabel, aria-brailleroledescription
+  * updates to aria-details to allow multiple IDREFS
 
 <!-- The latest status is updated in the [FAQ: What is the current status of
 WAI-ARIA development?](/WAI/aria/faq#update) -->

--- a/index.md
+++ b/index.md
@@ -99,12 +99,13 @@ It describes considerations that might not be evident to most authors from the W
 ## Versions {#versions}
 
 [WAI-ARIA 1.2](/TR/wai-aria-1.2/) was published as a completed W3C 
-Recommendation on 06 June 2023.
+Recommendation on 6 June 2023.
 
-[WAI-ARIA 1.3](/TR/wai-aria-1.3/) is under development. Proposed changes from ARIA 1.2 include:
+[WAI-ARIA 1.3 Draft](/TR/wai-aria-1.3/) is under development. Proposed changes from ARIA 1.2 include:
 * new roles: suggestion, comment, mark
 * new attributes: aria-description, aria-braillelabel, aria-brailleroledescription
-* updates to aria-details to allow multiple IDREFS
+* updates to aria-details to allow multiple IDrefs
+
 Additional changes are in the [changelog](https://www.w3.org/TR/wai-aria-1.3/#changelog)
 
 ### WAI-ARIA 1.2 {#wai-aria-1_2}

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ github:
   repository: w3c/wai-intro-aria
 feedbackmail: wai@w3.org
 footer: |
-  <p><strong>Date:</strong> Updated 19 May 2022. First published December 2006.</p>
+  <p><strong>Date:</strong> Updated 23 January 2024. First published December 2006.</p>
   <p><strong>Editors:</strong> James Nurthen, <a href="https://www.w3.org/People/cooper/">Michael Cooper</a>, <a href="https://www.w3.org/People/shawn/">Shawn Lawton Henry</a>.</p>
   <p>Developed with input from the Accessible Rich Internet Applications Working Group (<a href="https://www.w3.org/WAI/ARIA/">ARIA WG</a>) and the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>).</p>
 ---
@@ -101,7 +101,7 @@ It describes considerations that might not be evident to most authors from the W
 * [WAI-ARIA 1.2](/TR/wai-aria-1.2/) was published as a completed W3C 
 Recommendation on 06 June 2023.
 
-* [WAI-ARIA 1.3] is under development.
+* [WAI-ARIA 1.3](/TR/wai-aria-1.3/) is under development. First Public Working Draft (FPWD) was published 23 January 2024.
 
 <!-- The latest status is updated in the [FAQ: What is the current status of
 WAI-ARIA development?](/WAI/aria/faq#update) -->

--- a/index.md
+++ b/index.md
@@ -106,6 +106,8 @@ Recommendation on 06 June 2023.
   * new attributes: aria-description, aria-braillelabel, aria-brailleroledescription
   * updates to aria-details to allow multiple IDREFS
 
+Additional changes are in the [changelog](https://www.w3.org/TR/wai-aria-1.3/#changelog)
+
 <!-- The latest status is updated in the [FAQ: What is the current status of
 WAI-ARIA development?](/WAI/aria/faq#update) -->
 

--- a/index.md
+++ b/index.md
@@ -98,18 +98,14 @@ It describes considerations that might not be evident to most authors from the W
 
 ## Versions {#versions}
 
-* [WAI-ARIA 1.2](/TR/wai-aria-1.2/) was published as a completed W3C 
+[WAI-ARIA 1.2](/TR/wai-aria-1.2/) was published as a completed W3C 
 Recommendation on 06 June 2023.
 
-* [WAI-ARIA 1.3](/TR/wai-aria-1.3/) is under development. Proposed changes from ARIA 1.2 include:
-  * new roles: suggestion, comment, mark
-  * new attributes: aria-description, aria-braillelabel, aria-brailleroledescription
-  * updates to aria-details to allow multiple IDREFS
-
+[WAI-ARIA 1.3](/TR/wai-aria-1.3/) is under development. Proposed changes from ARIA 1.2 include:
+* new roles: suggestion, comment, mark
+* new attributes: aria-description, aria-braillelabel, aria-brailleroledescription
+* updates to aria-details to allow multiple IDREFS
 Additional changes are in the [changelog](https://www.w3.org/TR/wai-aria-1.3/#changelog)
-
-<!-- The latest status is updated in the [FAQ: What is the current status of
-WAI-ARIA development?](/WAI/aria/faq#update) -->
 
 ### WAI-ARIA 1.2 {#wai-aria-1_2}
 


### PR DESCRIPTION
This is only adding the link to the WAI-ARIA 1.3 FPWD.

@shawna-slh This does not include details on new ARIA 1.3 features. I think we should leave that for when the spec is more stable, for example when it reaches CR. Do you agree?